### PR TITLE
49 add proper user deletion

### DIFF
--- a/src/main/java/com/example/waytogo/audio/repository/AudioRepository.java
+++ b/src/main/java/com/example/waytogo/audio/repository/AudioRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 @Repository
 public interface AudioRepository extends JpaRepository<Audio, UUID> {
     Page<Audio> findByUser_Id(UUID uuid, PageRequest pageRequest);
+    Page<Audio> findByMapLocation_Id(UUID id, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/waytogo/audio/service/api/AudioService.java
+++ b/src/main/java/com/example/waytogo/audio/service/api/AudioService.java
@@ -14,6 +14,8 @@ public interface AudioService {
 
     Page<AudioDTO> getAllAudiosByUserId(UUID userId, Integer pageNumber, Integer pageSize);
 
+    Page<AudioDTO> getAllAudiosByMapLocationId(UUID mapLocationId, Integer pageNumber, Integer pageSize);
+
     AudioDTO saveNewAudio(@Valid AudioDTO audioDTO);
 
     Optional<AudioDTO> updateUserById(UUID audioId, @Valid AudioDTO audioDTO);

--- a/src/main/java/com/example/waytogo/audio/service/impl/AudioServiceJPA.java
+++ b/src/main/java/com/example/waytogo/audio/service/impl/AudioServiceJPA.java
@@ -62,6 +62,16 @@ public class AudioServiceJPA implements AudioService {
         return audioPage.map(audioMapper::audioToAudioDto);
     }
 
+    @Override
+    public Page<AudioDTO> getAllAudiosByMapLocationId(UUID mapLocationId, Integer pageNumber, Integer pageSize) {
+        PageRequest pageRequest = buildPageRequest(pageNumber, pageSize);
+
+        Page<Audio> audioPage;
+        audioPage = audioRepository.findByMapLocation_Id(mapLocationId, pageRequest);
+
+        return audioPage.map(audioMapper::audioToAudioDto);
+    }
+
 
     @Override
     public AudioDTO saveNewAudio(@Valid AudioDTO audioDTO) {

--- a/src/main/java/com/example/waytogo/maplocation/model/entity/MapLocation.java
+++ b/src/main/java/com/example/waytogo/maplocation/model/entity/MapLocation.java
@@ -30,10 +30,10 @@ public class MapLocation {
     @Column(name = "map_location_id", updatable = false, nullable = false)
     private UUID id;
 
-    @OneToMany(mappedBy="mapLocation")
+    @OneToMany(mappedBy="mapLocation", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Audio> audios;
 
-    @OneToMany(mappedBy = "mapLocation")
+    @OneToMany(mappedBy = "mapLocation", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<RouteMapLocation> routes;
 
     @Column(name = "name")

--- a/src/main/java/com/example/waytogo/maplocation/model/entity/MapLocation.java
+++ b/src/main/java/com/example/waytogo/maplocation/model/entity/MapLocation.java
@@ -30,10 +30,10 @@ public class MapLocation {
     @Column(name = "map_location_id", updatable = false, nullable = false)
     private UUID id;
 
-    @OneToMany(mappedBy="mapLocation", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy="mapLocation", fetch = FetchType.LAZY)
     private List<Audio> audios;
 
-    @OneToMany(mappedBy = "mapLocation", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "mapLocation", fetch = FetchType.LAZY)
     private List<RouteMapLocation> routes;
 
     @Column(name = "name")

--- a/src/main/java/com/example/waytogo/maplocation/service/impl/MapLocationServiceJPA.java
+++ b/src/main/java/com/example/waytogo/maplocation/service/impl/MapLocationServiceJPA.java
@@ -30,12 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MapLocationServiceJPA implements MapLocationService {
     private final MapLocationMapper mapLocationMapper;
     private final MapLocationRepository mapLocationRepository;
-
-    private final AudioService audioService;            //TODO is it correct? :
-    private final AudioRepository audioRepository;      //audio service is used for deleting audio when deleting map location
-                                                        //audio repository is used to get all audios by map location
-                                                        //if we wanted to use only audioservice we would have to map the result of service's method
-                                                        //to convert audioDTO to audio
+    private final AudioService audioService;
+    private final AudioRepository audioRepository;
     private final RouteMapLocationService routeMapLocationService;
     private final RouteMapLocationRepository routeMapLocationRepository;
 

--- a/src/main/java/com/example/waytogo/maplocation/service/impl/MapLocationServiceJPA.java
+++ b/src/main/java/com/example/waytogo/maplocation/service/impl/MapLocationServiceJPA.java
@@ -1,10 +1,16 @@
 package com.example.waytogo.maplocation.service.impl;
 
+import com.example.waytogo.audio.model.entity.Audio;
+import com.example.waytogo.audio.repository.AudioRepository;
+import com.example.waytogo.audio.service.api.AudioService;
 import com.example.waytogo.maplocation.mapper.MapLocationMapper;
 import com.example.waytogo.maplocation.model.dto.MapLocationDTO;
 import com.example.waytogo.maplocation.model.entity.MapLocation;
 import com.example.waytogo.maplocation.repository.MapLocationRepository;
 import com.example.waytogo.maplocation.service.api.MapLocationService;
+import com.example.waytogo.routes_maplocation.entity.RouteMapLocation;
+import com.example.waytogo.routes_maplocation.repository.RouteMapLocationRepository;
+import com.example.waytogo.routes_maplocation.service.api.RouteMapLocationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
@@ -13,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -23,6 +30,15 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MapLocationServiceJPA implements MapLocationService {
     private final MapLocationMapper mapLocationMapper;
     private final MapLocationRepository mapLocationRepository;
+
+    private final AudioService audioService;            //TODO is it correct? :
+    private final AudioRepository audioRepository;      //audio service is used for deleting audio when deleting map location
+                                                        //audio repository is used to get all audios by map location
+                                                        //if we wanted to use only audioservice we would have to map the result of service's method
+                                                        //to convert audioDTO to audio
+    private final RouteMapLocationService routeMapLocationService;
+    private final RouteMapLocationRepository routeMapLocationRepository;
+
     private static final Integer DEFAULT_PAGE = 0;
     private static final Integer DEFAULT_PAGE_SIZE = 25;
 
@@ -45,6 +61,17 @@ public class MapLocationServiceJPA implements MapLocationService {
     @Override
     public Boolean deleteMapLocationById(UUID mapLocationId) {
         if (mapLocationRepository.existsById(mapLocationId)) {
+
+            List<Audio> audios = audioRepository.findByMapLocation_Id(mapLocationId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+            for(Audio a : audios) {
+                audioService.deleteAudioById(a.getId());
+            }
+
+            List<RouteMapLocation> routeMapLocations = routeMapLocationRepository.findByMapLocation_Id(mapLocationId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+            for(RouteMapLocation rmp : routeMapLocations) {
+                routeMapLocationService.deleteRouteMapLocationById(rmp.getId());
+            }
+
             mapLocationRepository.deleteById(mapLocationId);
             return true;
         }

--- a/src/main/java/com/example/waytogo/route/model/entity/Route.java
+++ b/src/main/java/com/example/waytogo/route/model/entity/Route.java
@@ -29,7 +29,7 @@ public class Route {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "route", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "route")
     private List<RouteMapLocation> routeMapLocations;
 
     @NotBlank

--- a/src/main/java/com/example/waytogo/route/model/entity/Route.java
+++ b/src/main/java/com/example/waytogo/route/model/entity/Route.java
@@ -29,7 +29,7 @@ public class Route {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "route")
+    @OneToMany(mappedBy = "route", cascade = CascadeType.REMOVE)
     private List<RouteMapLocation> routeMapLocations;
 
     @NotBlank

--- a/src/main/java/com/example/waytogo/route/model/entity/Route.java
+++ b/src/main/java/com/example/waytogo/route/model/entity/Route.java
@@ -30,7 +30,7 @@ public class Route {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "route", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "route", fetch = FetchType.LAZY)
     private List<RouteMapLocation> routeMapLocations;
 
     @NotBlank

--- a/src/main/java/com/example/waytogo/route/model/entity/Route.java
+++ b/src/main/java/com/example/waytogo/route/model/entity/Route.java
@@ -26,10 +26,11 @@ public class Route {
     @Column(name="route_id", updatable=false, nullable=false)
     private UUID id;
 
+    //why fetch type lazy? user is not a collection
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "route", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "route", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<RouteMapLocation> routeMapLocations;
 
     @NotBlank

--- a/src/main/java/com/example/waytogo/route/service/impl/RouteServiceJPA.java
+++ b/src/main/java/com/example/waytogo/route/service/impl/RouteServiceJPA.java
@@ -5,6 +5,9 @@ import com.example.waytogo.route.model.dto.RouteDTO;
 import com.example.waytogo.route.model.entity.Route;
 import com.example.waytogo.route.repository.RouteRepository;
 import com.example.waytogo.route.service.api.RouteService;
+import com.example.waytogo.routes_maplocation.entity.RouteMapLocation;
+import com.example.waytogo.routes_maplocation.repository.RouteMapLocationRepository;
+import com.example.waytogo.routes_maplocation.service.api.RouteMapLocationService;
 import com.example.waytogo.user.mapper.UserMapper;
 import com.example.waytogo.user.model.dto.UserDTO;
 import jakarta.validation.Valid;
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,6 +34,9 @@ public class RouteServiceJPA implements RouteService {
     private final RouteMapper routeMapper;
 
     private final UserMapper userMapper;
+
+    private final RouteMapLocationService routeMapLocationService;
+    private final RouteMapLocationRepository routeMapLocationRepository;
 
     private final static int DEFAULT_PAGE = 0;
     private final static int DEFAULT_PAGE_SIZE = 25;
@@ -84,6 +91,11 @@ public class RouteServiceJPA implements RouteService {
     @Override
     public Boolean deleteRouteById(UUID routeId) {
         if (routeRepository.existsById(routeId)) {
+            List<RouteMapLocation> routeMapLocations = routeMapLocationRepository.findByRoute_Id(routeId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+            for(RouteMapLocation rmp : routeMapLocations) {
+                routeMapLocationService.deleteRouteMapLocationById(rmp.getId());
+            }
+
             routeRepository.deleteById(routeId);
             return true;
         }

--- a/src/main/java/com/example/waytogo/routes_maplocation/repository/RouteMapLocationRepository.java
+++ b/src/main/java/com/example/waytogo/routes_maplocation/repository/RouteMapLocationRepository.java
@@ -3,6 +3,7 @@ package com.example.waytogo.routes_maplocation.repository;
 import com.example.waytogo.maplocation.model.entity.MapLocation;
 import com.example.waytogo.routes_maplocation.entity.RouteMapLocation;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,7 @@ public interface RouteMapLocationRepository extends JpaRepository<RouteMapLocati
      */
     @Query("SELECT rml.mapLocation FROM RouteMapLocation rml WHERE rml.route.id = :routeId")
     Page<MapLocation> findMapLocationsByRouteId(@Param("routeId") UUID routeId, Pageable pageable);
+
+    Page<RouteMapLocation> findByMapLocation_Id(UUID id, PageRequest pageRequest);
+    Page<RouteMapLocation> findByRoute_Id(UUID id, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/waytogo/user/model/entity/User.java
+++ b/src/main/java/com/example/waytogo/user/model/entity/User.java
@@ -44,9 +44,20 @@ public class User {
     @Column(length = 50)
     String login;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user")
     List<Audio> audios;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user")
     List<Route> routes;
+
+    @PreRemove
+    private void preRemove() {
+        for (Route r : routes) {
+            r.setUser(null);
+        }
+
+        for (Audio a : audios) {
+            a.setUser(null);
+        }
+    }
 }

--- a/src/main/java/com/example/waytogo/user/model/entity/User.java
+++ b/src/main/java/com/example/waytogo/user/model/entity/User.java
@@ -44,20 +44,9 @@ public class User {
     @Column(length = 50)
     String login;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     List<Audio> audios;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     List<Route> routes;
-
-    @PreRemove
-    private void preRemove() {
-        for (Route r : routes) {
-            r.setUser(null);
-        }
-
-        for (Audio a : audios) {
-            a.setUser(null);
-        }
-    }
 }

--- a/src/main/java/com/example/waytogo/user/model/entity/User.java
+++ b/src/main/java/com/example/waytogo/user/model/entity/User.java
@@ -44,9 +44,9 @@ public class User {
     @Column(length = 50)
     String login;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     List<Audio> audios;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     List<Route> routes;
 }

--- a/src/main/java/com/example/waytogo/user/service/impl/UserServiceJPA.java
+++ b/src/main/java/com/example/waytogo/user/service/impl/UserServiceJPA.java
@@ -1,5 +1,9 @@
 package com.example.waytogo.user.service.impl;
 
+import com.example.waytogo.audio.model.entity.Audio;
+import com.example.waytogo.audio.repository.AudioRepository;
+import com.example.waytogo.route.model.entity.Route;
+import com.example.waytogo.route.repository.RouteRepository;
 import com.example.waytogo.user.mapper.UserMapper;
 import com.example.waytogo.user.model.dto.UserDTO;
 import com.example.waytogo.user.model.entity.User;
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -25,6 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class UserServiceJPA implements UserService {
     private final UserMapper userMapper;
     private final UserRepository userRepository;
+    private final RouteRepository routeRepository;
+    private final AudioRepository audioRepository;
 
     private final static int DEFAULT_PAGE = 0;
     private final static int DEFAULT_PAGE_SIZE = 25;
@@ -70,6 +77,16 @@ public class UserServiceJPA implements UserService {
     @Override
     public boolean deleteUserById(UUID userId) {
         if (userRepository.existsById(userId)) {
+            List<Route> routes = routeRepository.findByUser_Id(userId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+            for(Route r : routes) {
+                r.setUser(null);
+            }
+
+            List<Audio> audios = audioRepository.findByUser_Id(userId, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+            for(Audio a : audios) {
+                a.setUser(null);
+            }
+
             userRepository.deleteById(userId);
             return true;
         }

--- a/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
+++ b/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
@@ -268,16 +268,24 @@ class RouteControllerIT {
     @Rollback
     @Transactional
     @Test
-    @Disabled
-    @DisplayName("kumalale kumalale trzeba dorobić bo naruszenie wiezow integralnosci")
+    //@Disabled
+    //@DisplayName("kumalale kumalale trzeba dorobić bo naruszenie wiezow integralnosci")
     void testRouteExistanceAfterUserDeletion() {
         User user = userRepository.findAll().get(0);
         user.setRoutes(Collections.emptyList());
-        Route route = routeRepository.findAll().get(0);
-        route.setUser(user);
+        //Route route = routeRepository.findAll().get(0);
+        //route.setUser(user);
 
-        //userRepository.deleteById(user.getUserId());
-        //assertThat(routeRepository.existsById(route.getId())).isTrue();
+        Route newRoute = Route.builder()
+                        .user(user)
+                        .name("name")
+                        .id(UUID.randomUUID())
+                        .description(" ")
+                        .build();
+        routeRepository.save(newRoute);
+
+        userRepository.deleteById(user.getId());
+        assertThat(routeRepository.existsById(newRoute.getId())).isTrue();
 
     }
 

--- a/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
+++ b/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
@@ -90,7 +90,11 @@ class RouteControllerIT {
     @Transactional
     @Test
     void getRoutesEmpty() {
-        routeRepository.deleteAll();
+        for(Route r : routeRepository.findAll()) {
+            routeService.deleteRouteById(r.getId());
+        }
+
+
         Page<RouteDTO> page = routeController.getRoutes(1,20).getBody();
         assertThat(page.getContent().size()).isEqualTo(0);
     }

--- a/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
+++ b/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
@@ -7,6 +7,7 @@ import com.example.waytogo.route.repository.RouteRepository;
 import com.example.waytogo.route.service.api.RouteService;
 import com.example.waytogo.user.model.entity.User;
 import com.example.waytogo.user.repository.UserRepository;
+import com.example.waytogo.user.service.api.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +66,9 @@ class RouteControllerIT {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    UserService userService;
 
     @BeforeEach
     void setUp() {
@@ -265,31 +269,6 @@ class RouteControllerIT {
         });
     }
 
-    @Rollback
-    @Transactional
-    @Test
-    //@Disabled
-    //@DisplayName("kumalale kumalale trzeba dorobić bo naruszenie wiezow integralnosci")
-    void testRouteExistanceAfterUserDeletion() {
-        //https://stackoverflow.com/questions/5360795/what-is-the-difference-between-unidirectional-and-bidirectional-jpa-and-hibernat
-        //https://stackoverflow.com/questions/8434853/jpa-onetomany-update
-        User user = userRepository.findAll().get(0);
-        user.setRoutes(Collections.emptyList());
 
-        Route newRoute = Route.builder()
-                        .user(user)
-                        .name("name")
-                        .id(UUID.randomUUID())
-                        .description(" ")
-                        .build();
-        routeRepository.save(newRoute);
-
-        user = userRepository.findAll().get(0);
-
-
-        userRepository.deleteById(user.getId());
-        assertThat(routeRepository.existsById(newRoute.getId())).isTrue();
-
-    }
 
 }

--- a/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
+++ b/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
@@ -267,14 +267,15 @@ class RouteControllerIT {
 
     @Rollback
     @Transactional
+    @Commit
     @Test
     //@Disabled
     //@DisplayName("kumalale kumalale trzeba dorobić bo naruszenie wiezow integralnosci")
     void testRouteExistanceAfterUserDeletion() {
+        //https://stackoverflow.com/questions/5360795/what-is-the-difference-between-unidirectional-and-bidirectional-jpa-and-hibernat
+        //https://stackoverflow.com/questions/8434853/jpa-onetomany-update
         User user = userRepository.findAll().get(0);
         user.setRoutes(Collections.emptyList());
-        //Route route = routeRepository.findAll().get(0);
-        //route.setUser(user);
 
         Route newRoute = Route.builder()
                         .user(user)
@@ -283,6 +284,9 @@ class RouteControllerIT {
                         .description(" ")
                         .build();
         routeRepository.save(newRoute);
+
+        user = userRepository.findAll().get(0);
+
 
         userRepository.deleteById(user.getId());
         assertThat(routeRepository.existsById(newRoute.getId())).isTrue();

--- a/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
+++ b/src/test/java/com/example/waytogo/route/controller/RouteControllerIT.java
@@ -267,7 +267,6 @@ class RouteControllerIT {
 
     @Rollback
     @Transactional
-    @Commit
     @Test
     //@Disabled
     //@DisplayName("kumalale kumalale trzeba dorobić bo naruszenie wiezow integralnosci")

--- a/src/test/java/com/example/waytogo/route/service/impl/RouteServiceIT.java
+++ b/src/test/java/com/example/waytogo/route/service/impl/RouteServiceIT.java
@@ -5,12 +5,18 @@ import com.example.waytogo.route.model.dto.RouteDTO;
 import com.example.waytogo.route.model.entity.Route;
 import com.example.waytogo.route.repository.RouteRepository;
 import com.example.waytogo.route.service.api.RouteService;
+import com.example.waytogo.user.model.entity.User;
+import com.example.waytogo.user.repository.UserRepository;
+import com.example.waytogo.user.service.api.UserService;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +34,12 @@ class RouteServiceIT {
 
     @Autowired
     RouteRepository routeRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserService userService;
 
     Route testRoute;
     RouteDTO testRouteDTO;
@@ -56,6 +68,26 @@ class RouteServiceIT {
             RouteDTO routeDTO = routeService.saveNewRoute(testRouteDTO);
         });
 
+
+    }
+
+
+    @Rollback
+    @Transactional
+    @Test
+    void testRouteExistanceAfterUserDeletion() {
+        //https://stackoverflow.com/questions/5360795/what-is-the-difference-between-unidirectional-and-bidirectional-jpa-and-hibernat
+        //https://stackoverflow.com/questions/8434853/jpa-onetomany-update
+        User user = userRepository.findAll().get(0);
+        user.setRoutes(Collections.emptyList());
+
+        Route route = routeRepository.findAll().get(0);
+        route.setUser(user);
+
+        userService.deleteUserById(user.getId());
+
+        assertThat(routeRepository.existsById(route.getId())).isTrue();
+        assertThat(routeRepository.findById(route.getId()).get().getUser()).isNull();
 
     }
 

--- a/src/test/java/com/example/waytogo/route/service/impl/RouteServiceIT.java
+++ b/src/test/java/com/example/waytogo/route/service/impl/RouteServiceIT.java
@@ -76,8 +76,6 @@ class RouteServiceIT {
     @Transactional
     @Test
     void testRouteExistanceAfterUserDeletion() {
-        //https://stackoverflow.com/questions/5360795/what-is-the-difference-between-unidirectional-and-bidirectional-jpa-and-hibernat
-        //https://stackoverflow.com/questions/8434853/jpa-onetomany-update
         User user = userRepository.findAll().get(0);
         user.setRoutes(Collections.emptyList());
 

--- a/src/test/java/com/example/waytogo/route/service/impl/RouteServiceJPATest.java
+++ b/src/test/java/com/example/waytogo/route/service/impl/RouteServiceJPATest.java
@@ -1,6 +1,7 @@
 package com.example.waytogo.route.service.impl;
 
 import com.example.waytogo.route.repository.RouteRepository;
+import com.example.waytogo.routes_maplocation.repository.RouteMapLocationRepository;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -47,6 +48,9 @@ class RouteServiceJPATest {
 
     @Mock
     RouteMapper routeMapper;
+
+    @Mock
+    RouteMapLocationRepository routeMapLocationRepository;
 
     @InjectMocks
     RouteServiceJPA routeService;
@@ -120,6 +124,7 @@ class RouteServiceJPATest {
     @Test
     void deleteRouteById() {
         given(routeRepository.existsById(any(UUID.class))).willReturn(true);
+        given( routeMapLocationRepository.findByRoute_Id(any(UUID.class),any(PageRequest.class))).willReturn(Page.empty());
         Boolean result = routeService.deleteRouteById(testRoute.getId());
         assertThat(result).isTrue();
     }

--- a/src/test/java/com/example/waytogo/routes_maplocation/repository/RouteMapLocationRepositoryTest.java
+++ b/src/test/java/com/example/waytogo/routes_maplocation/repository/RouteMapLocationRepositoryTest.java
@@ -32,7 +32,7 @@ class RouteMapLocationRepositoryTest {
 
     @Test
     @Disabled
-    @DisplayName("jakis test na ta metode co zwraca malocations po route Id")
+    @DisplayName("jakis test na ta metode co zwraca malocations po  route Id")
     void doZrobienia() {
     }
 

--- a/src/test/java/com/example/waytogo/routes_maplocation/service/impl/RouteMapLocationServiceIT.java
+++ b/src/test/java/com/example/waytogo/routes_maplocation/service/impl/RouteMapLocationServiceIT.java
@@ -2,9 +2,11 @@ package com.example.waytogo.routes_maplocation.service.impl;
 
 import com.example.waytogo.maplocation.model.entity.MapLocation;
 import com.example.waytogo.maplocation.repository.MapLocationRepository;
+import com.example.waytogo.maplocation.service.api.MapLocationService;
 import com.example.waytogo.route.model.dto.RouteDTO;
 import com.example.waytogo.route.model.entity.Route;
 import com.example.waytogo.route.repository.RouteRepository;
+import com.example.waytogo.route.service.api.RouteService;
 import com.example.waytogo.routes_maplocation.entity.RouteMapLocation;
 import com.example.waytogo.routes_maplocation.repository.RouteMapLocationRepository;
 import com.example.waytogo.routes_maplocation.service.api.RouteMapLocationService;
@@ -37,7 +39,13 @@ class RouteMapLocationServiceIT {
     MapLocationRepository mapLocationRepository;
 
     @Autowired
+    MapLocationService mapLocationService;
+
+    @Autowired
     RouteRepository routeRepository;
+
+    @Autowired
+    RouteService routeService;
 
     @Autowired
     GeometryFactory geometryFactory;
@@ -46,6 +54,7 @@ class RouteMapLocationServiceIT {
     RouteDTO testRouteDTO;
     RouteMapLocation testRouteMapLocation;
     MapLocation testMapLocation;
+
 
     @BeforeEach
     void setUp() {
@@ -116,6 +125,32 @@ class RouteMapLocationServiceIT {
         assertThat(result).isNotNull();
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.get().getSequenceNr()).isEqualTo(routeMapLocation.getSequenceNr());
+
+    }
+
+    @Rollback
+    @Transactional
+    @Test
+    void testRouteMapLocationExistenceAfterRouteDeletion() {
+        RouteMapLocation rmp = routeMapLocationRepository.findAll().get(0);
+        Route route = routeRepository.findAll().get(0);
+        rmp.setRoute(route);
+
+        routeService.deleteRouteById(route.getId());
+        assertThat(routeMapLocationRepository.existsById(rmp.getId())).isFalse();
+
+    }
+
+    @Rollback
+    @Transactional
+    @Test
+    void testRouteMapLocationExistenceAfterMapLocationDeletion() {
+        RouteMapLocation rmp = routeMapLocationRepository.findAll().get(0);
+        MapLocation mapLocation = mapLocationRepository.findAll().get(0);
+        rmp.setMapLocation(mapLocation);
+
+        mapLocationService.deleteMapLocationById(mapLocation.getId());
+        assertThat(routeMapLocationRepository.existsById(rmp.getId())).isFalse();
 
     }
 

--- a/src/test/java/com/example/waytogo/user/controller/UserControllerIT.java
+++ b/src/test/java/com/example/waytogo/user/controller/UserControllerIT.java
@@ -61,7 +61,9 @@ class UserControllerIT {
     @Transactional
     @Test
     void testEmptyGetAllUsers() {
-        userRepository.deleteAll();
+        for(User u : userRepository.findAll()) {
+            userService.deleteUserById(u.getId());
+        }
         Page<UserDTO> dtos = userController.getAllUsers(1, 25);
 
         assertThat(dtos.getContent().size()).isEqualTo(0);


### PR DESCRIPTION

Zmieniłem proces usuwania encji w serwisie routes, mapLocation, user. 
- Po usunięciu Usera pola User w encjach routes i audios ustawiane są na null. 
- Po usunięciu route albo usunięciu mapLocation encje routeMapLocation są usuwane. 
- Po usunięciu mapLocation encje audios są usuwane.   

Dodałem też kilka testów sprawdzających usuwanie. 

Rada na przyszłość: Jeśli chcemy usunąć usera, routa czy coś innego należy skorzystać z serwisu (nie bezpośrednio z repozytorium)

Zerknij czy nie masz gdzieś wątpliwości w zmianach. 

dodatkowe linki do na przyszłość do bidirectional i unidirectional:
https://stackoverflow.com/questions/5360795/what-is-the-difference-between-unidirectional-and-bidirectional-jpa-and-hibernat
https://stackoverflow.com/questions/8434853/jpa-onetomany-update